### PR TITLE
Update codesign binary name.

### DIFF
--- a/Microsoft.Xbox.Service.DevTools/Microsoft.Xbox.Live.SDK.DevTools.nuspec
+++ b/Microsoft.Xbox.Service.DevTools/Microsoft.Xbox.Live.SDK.DevTools.nuspec
@@ -4,13 +4,13 @@
     <id>$id$</id>
     <version>$version$</version>
     <title>$title$</title>
-    <authors>$author$</authors>
-    <owners>$author$</owners>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
     <licenseUrl>https://aka.ms/xblsdklicense</licenseUrl>
     <projectUrl>https://github.com/Microsoft/xbox-live-developer-tools</projectUrl>
     <iconUrl>http://www.xbox.com/shell/images/shell/XboxLogo.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>$description$</description>
+    <description>Microsoft Xbox Live Developer Tooling API</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>Microsoft Xbox Live Service XSAPI Tool</tags>
   </metadata>

--- a/signConfig.xml
+++ b/signConfig.xml
@@ -4,7 +4,7 @@
     <file src="__RELBINPATH__\bin\GlobalStorage\GlobalStorage.exe" signType="Authenticode" dest="__RELBINPATH__\bin\GlobalStorage\GlobalStorage.exe" />
     <file src="__RELBINPATH__\bin\Microsoft.Xbox.Services.DevTools\Microsoft.Xbox.Services.DevTools.dll" signType="Authenticode" dest="__RELBINPATH__\bin\Microsoft.Xbox.Services.DevTools\Microsoft.Xbox.Services.DevTools.dll" />
     <file src="__RELBINPATH__\bin\PlayerDataReset\PlayerDataReset.exe" signType="Authenticode" dest="__RELBINPATH__\bin\PlayerDataReset\PlayerDataReset.exe" />
-    <file src="__RELBINPATH__\bin\SessionHistoryViewer\SessionHistoryViewer.exe" signType="Authenticode" dest="__RELBINPATH__\bin\SessionHistoryViewer\SessionHistoryViewer.exe" />
+    <file src="__RELBINPATH__\bin\SessionHistoryViewer\MultiplayerSessionHistoryViewer.exe" signType="Authenticode" dest="__RELBINPATH__\bin\SessionHistoryViewer\MultiplayerSessionHistoryViewer.exe" />
     <file src="__RELBINPATH__\bin\XblDevAccount\XblDevAccount.exe" signType="Authenticode" dest="__RELBINPATH__\bin\XblDevAccount\XblDevAccount.exe" />
   </job>
 </SignConfigXML>


### PR DESCRIPTION
Update codesign binary name.
Change nuget spec to use hardcoded string to fix incorrect population by build machine.