### PR TITLE
Implement MSAL Credential Caching

### DIFF
--- a/CommandLine/XblPlayerDataReset/Program.cs
+++ b/CommandLine/XblPlayerDataReset/Program.cs
@@ -147,6 +147,7 @@ namespace XblPlayerDataReset
                 {
                     Console.Error.WriteLine("The file could not be read:");
                     Console.Error.WriteLine("The file appears to have no content.");
+                    Console.Error.WriteLine(ne.Message);
                 }
                 catch (Exception e)
                 {

--- a/Microsoft.Xbox.Service.DevTools/Authentication/IAuthContext.cs
+++ b/Microsoft.Xbox.Service.DevTools/Authentication/IAuthContext.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Xbox.Services.DevTools.Authentication
 {
     using System.Threading.Tasks;
+    using Microsoft.Identity.Client;
 
     internal interface IAuthContext
     {
@@ -20,5 +21,9 @@ namespace Microsoft.Xbox.Services.DevTools.Authentication
         Task<string> AcquireTokenSilentAsync();
 
         Task<string> AcquireTokenAsync();
+
+        Task<bool> HasCredentialAsync();
+
+        Task<IAccount> SearchAccounts();
     }
 }

--- a/Microsoft.Xbox.Service.DevTools/Authentication/MsalTokenCache.cs
+++ b/Microsoft.Xbox.Service.DevTools/Authentication/MsalTokenCache.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Xbox.Services.DevTools.Authentication
+{
+    using System.IO;
+    using System.Security.Cryptography;
+    using Microsoft.Identity.Client;
+    using Microsoft.Xbox.Services.DevTools.Common;
+
+    internal class MsalTokenCache
+    {
+        private const string CacheFile = "msal.cache";
+
+        private static readonly object FileLock = new object();
+
+        public MsalTokenCache()
+        {
+            Directory.CreateDirectory(ClientSettings.Singleton.CacheFolder);
+        }
+
+        public void EnableSerialization(ITokenCache tokenCache)
+        {
+            tokenCache.SetBeforeAccess(this.BeforeAccessNotification);
+            tokenCache.SetAfterAccess(this.AfterAccessNotification);
+        }
+
+        private void BeforeAccessNotification(TokenCacheNotificationArgs args)
+        {
+            lock (FileLock)
+            {
+                string cacheFilePath = Path.Combine(ClientSettings.Singleton.CacheFolder, CacheFile);
+
+                args.TokenCache.DeserializeMsalV3(File.Exists(cacheFilePath)
+                    ? ProtectedData.Unprotect(File.ReadAllBytes(cacheFilePath), null, DataProtectionScope.CurrentUser) : null);
+            }
+        }
+
+        private void AfterAccessNotification(TokenCacheNotificationArgs args)
+        {
+            lock (FileLock)
+            {
+                string cacheFilePath = Path.Combine(ClientSettings.Singleton.CacheFolder, CacheFile);
+
+                File.WriteAllBytes(cacheFilePath, ProtectedData.Protect(args.TokenCache.SerializeMsalV3(), null, DataProtectionScope.CurrentUser));
+            }
+        }
+    }
+}

--- a/Microsoft.Xbox.Service.DevTools/Microsoft.Xbox.Services.DevTools.csproj
+++ b/Microsoft.Xbox.Service.DevTools/Microsoft.Xbox.Services.DevTools.csproj
@@ -52,9 +52,8 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Identity.Client, Version=4.60.3.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae">
-      <HintPath>..\packages/Microsoft.Identity.Client.4.60.3/lib/net462/Microsoft.Identity.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Identity.Client, Version=4.62.0.0, Culture=neutral, PublicKeyToken=0a613f4dd989e8ae, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Identity.Client.4.62.0\lib\net462\Microsoft.Identity.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Abstractions, Version=6.35.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.6.35.0\lib\net462\Microsoft.IdentityModel.Abstractions.dll</HintPath>
@@ -98,6 +97,7 @@
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
+    <Reference Include="System.Security" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
@@ -112,6 +112,7 @@
     <Compile Include="Authentication\DevAccount.cs" />
     <Compile Include="Authentication\DevAccountSource.cs" />
     <Compile Include="Authentication\MsalTestAuthContext.cs" />
+    <Compile Include="Authentication\MsalTokenCache.cs" />
     <Compile Include="Authentication\TestAccount.cs" />
     <Compile Include="Authentication\ToolAuthentication.cs" />
     <Compile Include="Authentication\AuthTokenCache.cs" />

--- a/Microsoft.Xbox.Service.DevTools/PlayerReset/PlayerReset.cs
+++ b/Microsoft.Xbox.Service.DevTools/PlayerReset/PlayerReset.cs
@@ -98,6 +98,7 @@ namespace Microsoft.Xbox.Services.DevTools.PlayerReset
             {
                 result.OverallResult = ResetOverallResult.Succeeded;
             }
+            
             return result;
         }
 

--- a/Microsoft.Xbox.Service.DevTools/packages.config
+++ b/Microsoft.Xbox.Service.DevTools/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Interop.CERTENROLLLib.Unofficial" version="1.0.0" targetFramework="net462" />
-  <package id="Microsoft.Identity.Client" version="4.60.3" targetFramework="net462" />
+  <package id="Microsoft.Identity.Client" version="4.62.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Abstractions" version="6.35.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />

--- a/custom.props
+++ b/custom.props
@@ -14,7 +14,7 @@
   </Choose>
 
   <PropertyGroup Label="Version">
-    <VersionMajor>2023</VersionMajor>
+    <VersionMajor>2024</VersionMajor>
     <VersionMinor>03</VersionMinor>
     <VersionInfoProductName>Xbox Live Dev Tools</VersionInfoProductName>
   </PropertyGroup>


### PR DESCRIPTION
Adding new MsalTokenCache to create msal.cache file to be used to save XBL Dev Account credentials to be used across other Xbox Live executables. 

Fixing XBLConfig issue:
'No account or login hint was passed to the AcquireTokenSilent call.'
After using XBLDevAccount to login 

