### PR TITLE
fix incorrect dll system.management.automation.dll

### DIFF
--- a/Microsoft.Xbox.Service.DevTools/Microsoft.Xbox.Services.DevTools.csproj
+++ b/Microsoft.Xbox.Service.DevTools/Microsoft.Xbox.Services.DevTools.csproj
@@ -82,8 +82,7 @@
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.PowerShell.5.ReferenceAssemblies.1.1.0\lib\net4\System.Management.Automation.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>

--- a/Microsoft.Xbox.Service.DevTools/packages.config
+++ b/Microsoft.Xbox.Service.DevTools/packages.config
@@ -4,12 +4,12 @@
   <package id="Microsoft.Identity.Client" version="4.62.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Abstractions" version="6.35.0" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.1" targetFramework="net45" />
+  <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.1" targetFramework="net462" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net45" />
-  <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net45" />
   <package id="System.Memory" version="4.5.4" targetFramework="net462" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />

--- a/Powershell/XblConfig/XblConfig.PS.csproj
+++ b/Powershell/XblConfig/XblConfig.PS.csproj
@@ -42,8 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\Microsoft.PowerShell.5.ReferenceAssemblies.1.1.0\lib\net4\System.Management.Automation.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Powershell/XblConfig/packages.config
+++ b/Powershell/XblConfig/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Costura.Fody" version="2.0.1" targetFramework="net461" />
   <package id="Fody" version="3.0.3" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0" targetFramework="net462" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
-  <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net461" />
   <package id="XmlDoc2CmdletDoc" version="0.2.10" targetFramework="net462" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Removed the suspicious nuget package of `system.management.automation.dll` as is not the oficial nuget from microsoft. The avalaible versions of  `system.management.automation` does not support .net framework 4.6.2 a work around is to use the nuget `\Microsoft.PowerShell.5.ReferenceAssemblies.1.1.0` as this is intended to be use in .net 4.6.x projects and is published by the powershell team