### PR TITLE
Accounting for the possibility that user will initialize as 'Xorc' in…

### DIFF
--- a/Microsoft.Xbox.Service.DevTools/XblConfig/History.cs
+++ b/Microsoft.Xbox.Service.DevTools/XblConfig/History.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Xbox.Services.DevTools.XblConfig
         /// <summary>
         /// Gets or sets the user ID of the user that initiated the commit.
         /// </summary>
-        public ulong User { get; set; }
+        public string User { get; set; }
 
         /// <summary>
         /// Gets or sets the version of the changeset.


### PR DESCRIPTION
…stead of a long before publishing an initial service config

This fixes a JSON deserialization issue when trying to read the commit history of a fresh title's service config