### PR TITLE
Add an option to authenticate silently

### DIFF
--- a/CommandLine/XblPlayerDataReset/Program.cs
+++ b/CommandLine/XblPlayerDataReset/Program.cs
@@ -164,7 +164,7 @@ namespace XblPlayerDataReset
                 // Sign into each account individually
                 foreach (string testAccountName in testAccountNames)
                 {
-                    TestAccount ta = await ToolAuthentication.SignInTestAccountAsync(testAccountName, options.Sandbox);
+                    TestAccount ta = await ToolAuthentication.SignInTestAccountAsync(testAccountName, options.Sandbox, options.Silent);
 
                     // If we have a failure, output the account and stop the process
                     if (ta == null)
@@ -302,6 +302,10 @@ namespace XblPlayerDataReset
             [Option('d', "delimiter", Required = false, Default = ",",
                 HelpText = "Delimiter that separates accounts to reset. Defaults to \",\".")]
             public string Delimiter { get; set; }
+
+            [Option('i', "silent", Required = false,
+                HelpText = "Connect to the account using cached credentials. May still open UI if authentification is necessary.")]
+            public bool Silent { get; set; }
 
             [Usage(ApplicationAlias = "XblPlayerDataReset")]
             public static IEnumerable<Example> Examples

--- a/Microsoft.Xbox.Service.DevTools/Authentication/AuthClient.cs
+++ b/Microsoft.Xbox.Service.DevTools/Authentication/AuthClient.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Xbox.Services.DevTools.Authentication
     using System.Net.Http;
     using System.Threading.Tasks;
     using DevTools.Common;
+    using Microsoft.Identity.Client;
     using Newtonsoft.Json;
 
     internal class AuthClient
@@ -111,7 +112,7 @@ namespace Microsoft.Xbox.Services.DevTools.Authentication
             return account;
         }
 
-        public async Task<TestAccount> SignInTestAccountAsync(string sandbox)
+        public async Task<TestAccount> SignInTestAccountAsync(string sandbox, bool tryCached)
         {
             if (this.AuthContext == null)
             {
@@ -128,7 +129,23 @@ namespace Microsoft.Xbox.Services.DevTools.Authentication
                 throw new InvalidOperationException("To log in a Partner Center account, call the SignInAsync method");
             }
 
-            string msaToken = await this.AuthContext.AcquireTokenAsync();
+            string msaToken;
+            if (!tryCached)
+            {
+                msaToken = await this.AuthContext.AcquireTokenAsync();
+            }
+            else
+            {
+                try
+                {
+                    msaToken = await this.AuthContext.AcquireTokenSilentAsync();
+                }
+                catch (MsalUiRequiredException)
+                {
+                    msaToken = await this.AuthContext.AcquireTokenAsync();
+                }
+            }
+
             XasTokenResponse token = await this.FetchXstsToken(msaToken, sandbox);
 
             var account = new TestAccount(token);

--- a/Microsoft.Xbox.Service.DevTools/Authentication/ToolAuthentication.cs
+++ b/Microsoft.Xbox.Service.DevTools/Authentication/ToolAuthentication.cs
@@ -129,12 +129,14 @@ namespace Microsoft.Xbox.Services.DevTools.Authentication
         /// Attempt to sign in a test account, UI will be triggered if necessary 
         /// </summary>
         /// <param name="userName">The user name of the account, optional.</param>
+        /// <param name="sandbox">The target sandbox for the XToken</param>
+        /// <param name="tryCached">Try authentifying using cached credential first</param>
         /// <returns>TestAccount object contains test account info.</returns>
-        public static async Task<TestAccount> SignInTestAccountAsync(string userName, string sandbox)
+        public static async Task<TestAccount> SignInTestAccountAsync(string userName, string sandbox, bool tryCached)
         {
             SetAuthInfo(DevAccountSource.TestAccount, userName, "consumers");
 
-            TestAccount testAccount = await Client.SignInTestAccountAsync(sandbox);
+            TestAccount testAccount = await Client.SignInTestAccountAsync(sandbox, tryCached);
             return testAccount;
         }
 


### PR DESCRIPTION
We needed to reset player data in our automated test pipeline and found out that it wasn't possible because the sign in dialog was always triggering. Everything was already supported internally. We implemented a new option to authenticate automatically if possible. The sign in dialog will still show if necessary.