### PR TITLE
Keep dependency DLLs on disk for analysis and align CommandLineParser version

### DIFF
--- a/CommandLine/GlobalStorage/FodyWeavers.xml
+++ b/CommandLine/GlobalStorage/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
+  <Costura DisableCleanup="true" />
 </Weavers>

--- a/CommandLine/XblConfig/FodyWeavers.xml
+++ b/CommandLine/XblConfig/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
+  <Costura DisableCleanup="true" />
 </Weavers>

--- a/CommandLine/XblConnectedStorage/FodyWeavers.xml
+++ b/CommandLine/XblConnectedStorage/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
+  <Costura DisableCleanup="true" />
 </Weavers>

--- a/CommandLine/XblDevAccount/FodyWeavers.xml
+++ b/CommandLine/XblDevAccount/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
+  <Costura DisableCleanup="true" />
 </Weavers>

--- a/CommandLine/XblDevAccount/XblDevAccount.csproj
+++ b/CommandLine/XblDevAccount/XblDevAccount.csproj
@@ -39,8 +39,8 @@
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.9.1.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommandLineParser.2.9.1\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.2.1.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommandLineParser.2.2.1\lib\net45\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Costura, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Costura.Fody.6.0.0\lib\netstandard2.0\Costura.dll</HintPath>

--- a/CommandLine/XblDevAccount/packages.config
+++ b/CommandLine/XblDevAccount/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.9.1" targetFramework="net462" />
+  <package id="CommandLineParser" version="2.2.1" targetFramework="net462" />
   <package id="Costura.Fody" version="6.0.0" targetFramework="net462" developmentDependency="true" />
   <package id="Fody" version="6.9.3" targetFramework="net462" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net462" developmentDependency="true" />

--- a/CommandLine/XblPlayerDataReset/FodyWeavers.xml
+++ b/CommandLine/XblPlayerDataReset/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
+  <Costura DisableCleanup="true" />
 </Weavers>

--- a/Microsoft.Xbox.Service.DevTools/Common/ClientSettings.cs
+++ b/Microsoft.Xbox.Service.DevTools/Common/ClientSettings.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Xbox.Services.DevTools.Common
 
         public string XCertEndpoint { get; private set; } = "https://cert.mgt.xboxlive.com/";
 
-        public string XAchEndpoint { get; private set; } = "https://xblconfiggateway.xboxservices.com/";
+        public string XblConfigGatewayEndpoint { get; private set; } = "https://xblconfiggateway.xboxservices.com/";
 
         public string XFusEndpoint { get; private set; } = "https://upload.xboxlive.com/";
 

--- a/Microsoft.Xbox.Service.DevTools/XblConfig/ConfigurationManager.cs
+++ b/Microsoft.Xbox.Service.DevTools/XblConfig/ConfigurationManager.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Xbox.Services.DevTools.XblConfig
         private static Uri xconUri = new Uri(ClientSettings.Singleton.XConEndpoint);
         private static Uri xorcUri = new Uri(ClientSettings.Singleton.XOrcEndpoint);
         private static Uri xcertUri = new Uri(ClientSettings.Singleton.XCertEndpoint);
-        private static Uri xachUri = new Uri(ClientSettings.Singleton.XAchEndpoint);
+        private static Uri xblConfigGatewayUri = new Uri(ClientSettings.Singleton.XblConfigGatewayEndpoint);
         private static Uri xfusUri = new Uri(ClientSettings.Singleton.XFusEndpoint);
 
         private static int maxQueryCount = 50;
@@ -832,7 +832,7 @@ namespace Microsoft.Xbox.Services.DevTools.XblConfig
             {
                 XboxLiveHttpResponse response = await request.SendAsync(() =>
                 {
-                    return new HttpRequestMessage(HttpMethod.Get, new Uri(xachUri, $"/achievementimages/scids/{scid}/images/{assetId}"));
+                    return new HttpRequestMessage(HttpMethod.Get, new Uri(xblConfigGatewayUri, $"/achievementimages/scids/{scid}/images/{assetId}"));
                 });
                 using (HttpResponseMessage httpResponse = response.Response)
                 {
@@ -863,7 +863,7 @@ namespace Microsoft.Xbox.Services.DevTools.XblConfig
                 {
                     XboxLiveHttpResponse response = await request.SendAsync(() =>
                     {
-                        return new HttpRequestMessage(HttpMethod.Get, new Uri(xachUri, $"/achievementimages/scids/{scid}/images/?start={page * maxQueryCount}&count={maxQueryCount}"));
+                        return new HttpRequestMessage(HttpMethod.Get, new Uri(xblConfigGatewayUri, $"/achievementimages/scids/{scid}/images/?start={page * maxQueryCount}&count={maxQueryCount}"));
                     });
                     using (HttpResponseMessage httpResponse = response.Response)
                     {
@@ -907,7 +907,7 @@ namespace Microsoft.Xbox.Services.DevTools.XblConfig
             {
                 XboxLiveHttpResponse response = await request.SendAsync(() =>
                 {
-                    return new HttpRequestMessage(HttpMethod.Post, new Uri(xachUri, "/achievementimages/assets/initialize"));
+                    return new HttpRequestMessage(HttpMethod.Post, new Uri(xblConfigGatewayUri, "/achievementimages/assets/initialize"));
                 });
                 using (HttpResponseMessage httpResponse = response.Response)
                 {
@@ -997,7 +997,7 @@ namespace Microsoft.Xbox.Services.DevTools.XblConfig
             {
                 XboxLiveHttpResponse response = await request.SendAsync(() =>
                 {
-                    HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, new Uri(xachUri, $"/achievementimages/scids/{scid}/images"));
+                    HttpRequestMessage message = new HttpRequestMessage(HttpMethod.Post, new Uri(xblConfigGatewayUri, $"/achievementimages/scids/{scid}/images"));
                     AchievementImageUploadRequest requestBody = new AchievementImageUploadRequest() { XfusId = xfusId };
                     message.Content = new StringContent(requestBody.ToJson());
                     message.Content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");

--- a/Powershell/XblConfig/FodyWeavers.xml
+++ b/Powershell/XblConfig/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
+  <Costura DisableCleanup="true" />
 </Weavers>

--- a/Tests/Microsoft.Xbox.Services.DevTools.Unittest/XblConfigTest.cs
+++ b/Tests/Microsoft.Xbox.Services.DevTools.Unittest/XblConfigTest.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Xbox.Services.DevTools.Unittest
             int fileSize = (int)image.Length;
             Guid xfusId = Guid.NewGuid();
             string xfusToken = "1234";
-            Uri initUri = new Uri(new Uri(ClientSettings.Singleton.XAchEndpoint), "/achievementimages/assets/initialize");
+            Uri initUri = new Uri(new Uri(ClientSettings.Singleton.XblConfigGatewayEndpoint), "/achievementimages/assets/initialize");
 
             XachInitializeResponse initResponse = new XachInitializeResponse()
             {
@@ -349,7 +349,7 @@ namespace Microsoft.Xbox.Services.DevTools.Unittest
                 .WithHeaders("Authorization", expectedToken)
                 .Respond(res => this.ExpectedJsonResponse(uploadResponse));
 
-            Uri finalizeUri = new Uri(new Uri(ClientSettings.Singleton.XAchEndpoint), $"/achievementimages/scids/{DefaultScid}/images");
+            Uri finalizeUri = new Uri(new Uri(ClientSettings.Singleton.XblConfigGatewayEndpoint), $"/achievementimages/scids/{DefaultScid}/images");
 
             this.mockHandler.Expect(finalizeUri.ToString())
                 .WithHeaders("Authorization", expectedToken)

--- a/Tools/MultiplayerSessionHistoryViewer/FodyWeavers.xml
+++ b/Tools/MultiplayerSessionHistoryViewer/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
+  <Costura DisableCleanup="true" />
 </Weavers>


### PR DESCRIPTION
## Summary

Two small build-configuration fixes to the command-line tools:

1. **Keep dependency DLLs available on disk for static analysis.** The recent Costura.Fody `2.0.1 -> 6.0.0` upgrade changed Costura''s default behavior: in addition to embedding copy-local dependencies into each tool executable, it now also deletes the loose dependency DLLs from the build output. Setting `<Costura DisableCleanup="true" />` keeps those DLLs on disk in the build output while still embedding them in the exe, so static-analysis tooling that inspects the build artifacts can resolve them again. Runtime behavior and the packaged tools (which ship the single self-contained exe) are unchanged.

2. **Make the CommandLineParser version consistent across the tools.** XblDevAccount had been bumped to `CommandLineParser` 2.9.1 while the other tools remained on 2.2.1 (a different version and signing key). This reverts XblDevAccount back to 2.2.1 so all tools use the same version.

## Changes

- Set `<Costura DisableCleanup="true" />` in the `FodyWeavers.xml` of all seven Costura projects.
- Revert XblDevAccount `CommandLineParser` 2.9.1 -> 2.2.1 (`packages.config` + project reference).

## Validation

- Builds succeed; the loose `CommandLine.dll` is confirmed present in the build output for XblDevAccount and GlobalStorage after the change.
- No source code changes required.

## Additional change

Renamed `XAch*` variable names to `XblConfigGateway*` to match current endpoint